### PR TITLE
DB에 이터니티,데미갓 mmr 저장 스케줄

### DIFF
--- a/ER_EC2/get_top_ranking_players.sh
+++ b/ER_EC2/get_top_ranking_players.sh
@@ -1,0 +1,1 @@
+python insert_mongoDB.py --t 1

--- a/ER_EC2/get_top_ranking_players.sh
+++ b/ER_EC2/get_top_ranking_players.sh
@@ -1,1 +1,1 @@
-python insert_mongoDB.py --t 1
+nohup python insert_mongoDB.py --t 1 &

--- a/ER_EC2/init_scheduler.sh
+++ b/ER_EC2/init_scheduler.sh
@@ -18,5 +18,7 @@ echo "ER_DIR_PATH=${ER_DIR_PATH}" >> cron_backup
 echo "*/30 * * * * ${ER_DIR_PATH}/storage_check.sh >> ${ER_DIR_PATH}/logs/storage_check.log 2>&1" >> cron_backup
 # insert game match datas every day 00:00
 echo "0 0 * * * ${ER_DIR_PATH}/insert_to_mongoDB.sh >> ${ER_DIR_PATH}/logs/insert_to_mongoDB.log 2>&1" >> cron_backup
+# insert top ranking players
+echo "0 9 * * * ${ER_DIR_PATH}/get_top_ranking_players.sh > ${ER_DIR_PATH}/logs/get_top_ranking_players.sh 2>&1" >> cron_backup
 # editing crontab done
 crontab cron_backup

--- a/ER_EC2/insert_mongoDB.py
+++ b/ER_EC2/insert_mongoDB.py
@@ -4,14 +4,16 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from ER_apis.ER_DB import (
     insert_game_play_datas_mongoDB,
+    insert_game_top_players_mmr_mongoDB,
     get_highest_id,
     get_recent_game_id_from_ranker,
+    get_ranker_mmr,
 )
 import argparse
 
 argument_parser = argparse.ArgumentParser()
 argument_parser.add_argument("--n", help="GameNumbersToSave", type=int, default=1000)
-
+argument_parser.add_argument("--t", help="Add Top Ranking Player Datas", type=int, default=0)
 # need to optimaze
 # 1. how to get from_game_id to save
 # 2. how often to get apis.(current: every 00:00)
@@ -19,13 +21,18 @@ argument_parser.add_argument("--n", help="GameNumbersToSave", type=int, default=
 # 3.1 if we fetch datas too often, then the ranker's recent game_id won't change.
 
 if __name__ == "__main__":
+    top_ranker_player_data_flag = argument_parser.parse_args().t
+    if top_ranker_player_data_flag==1:
+        if insert_game_top_players_mmr_mongoDB():
+            exit(0)
+        exit(1)
     highest_game_id_in_DB = get_highest_id()
     recent_game_id_from_top_ranker = get_recent_game_id_from_ranker()
     print("highest_game_id_in_DB: ", highest_game_id_in_DB)
     print("recent_game_id_from_top_ranker: ", recent_game_id_from_top_ranker)
     from_game_id = recent_game_id_from_top_ranker
     game_numbers_to_save = argument_parser.parse_args().n
-
+    
     # don't use added value
     # have to prevent duplicated key(game id) error
 

--- a/ER_apis/ER_DB.py
+++ b/ER_apis/ER_DB.py
@@ -5,7 +5,7 @@ import json
 from .cryption_secret import AESCipher
 import requests
 import time
-from ER_apis.ER_api import request_to_ER_api
+from ER_apis.ER_api import request_to_ER_api, request_top_players
 from dotenv import load_dotenv
 import os
 
@@ -16,7 +16,8 @@ RANK_MODE_NUMBER = int(os.environ.get("RANK_MODE_NUMBER"))
 COBALT_MODE_NUMBER = int(os.environ.get("COBALT_MODE_NUMBER"))
 OK_RESPONSE = int(os.environ.get("OK_RESPONSE"))
 SEASON_ID = int(os.environ.get("SEASON_ID"))
-
+ETERNITY_CUT=199
+DEMIGOD_CUT=699
 
 def get_mongoDB_connection_string():
     with open("setting/secret_db.json", "r", encoding="utf-8") as f:
@@ -28,14 +29,32 @@ def get_mongoDB_connection_string():
     return RW_EC2_DB_CONNECTION_STRING, READ_EC2_DB_CONNECTION_STRING
 
 
+def get_mongoDB_connection_string_from_env():
+    RW_EC2_DB_CONNECTION_STRING = os.environ.get("RW_EC2_DB_CONNECTION_STRING")
+    READ_EC2_DB_CONNECTION_STRING = os.environ.get("READ_EC2_DB_CONNECTION_STRING")
+    return RW_EC2_DB_CONNECTION_STRING, READ_EC2_DB_CONNECTION_STRING
+
 def access_RW_mongoDB() -> MongoClient:
-    RW_DB_CONNECTION_STRING = get_mongoDB_connection_string()[0]
+    RW_DB_CONNECTION_STRING = get_mongoDB_connection_string_from_env()[0]
     client = MongoClient(RW_DB_CONNECTION_STRING, port=27017)
     return client
 
+def test_access_mongoDB()->MongoClient:
+    RW_EC2_DB_CONNECTION_STRING, READ_EC2_DB_CONNECTION_STRING=get_mongoDB_connection_string_from_env()
+    try:
+        rw_client = MongoClient(RW_EC2_DB_CONNECTION_STRING, port=27017)
+        rw_client.get_database("ERDB")
+        read_client = MongoClient(READ_EC2_DB_CONNECTION_STRING, port=27017)
+        read_client.get_database("ERDB")
+        collection = read_client.get_database("ERDB")["game_play_datas"]
+
+    except Exception as e:
+        print("Error Occured From Test Connection to mongoDB")
+        return False
+    return True
 
 def access_read_mongoDB() -> MongoClient:
-    READ_DB_CONNECTION_STRING = get_mongoDB_connection_string()[1]
+    READ_DB_CONNECTION_STRING = get_mongoDB_connection_string_from_env()[1]
     client = MongoClient(READ_DB_CONNECTION_STRING, port=27017)
     return client
 
@@ -137,6 +156,25 @@ def insert_game_play_datas_mongoDB(
     print("[[insert end]]")
     return True
 
+def insert_game_top_players_mmr_mongoDB(
+    error_stop: bool = True
+) -> bool:
+    client = access_RW_mongoDB()
+    access_db = client["ERDB"]
+    collection = access_db["top_rank_players"]
+    responced_top_ranker_mmr_Data = request_top_players()
+    if responced_top_ranker_mmr_Data==None:
+        print("Responced Top Ranker's Data is empty")
+        return False
+    try:
+        result = collection.insert_one(responced_top_ranker_mmr_Data)
+    except Exception as e:
+        print(f"Error: {e}")
+        if error_stop:
+            return False   
+    client.close()
+    return True    
+
 
 def get_lowest_id() -> int:
     client = access_RW_mongoDB()
@@ -161,6 +199,18 @@ def get_highest_id() -> int:
     else:
         return None
 
+def get_ranker_mmr(eternity:bool=True,demigod:bool=False)->list[int]:
+    client = access_RW_mongoDB()
+    collection = client["ERDB"]["top_rank_players"]
+    recent_document = collection.find().sort({"dateCreated":1}).limit(1).__getitem__(0)
+    eternity_mmr = recent_document["topRanks"][ETERNITY_CUT]["mmr"]
+    demigod_mmr = recent_document["topRanks"][DEMIGOD_CUT]["mmr"]
+    mmr = []
+    if eternity:
+        mmr.append(eternity_mmr)
+    if demigod:
+        mmr.append(demigod_mmr)
+    return mmr
 
 def get_all_match_datas_from_mongoDB() -> list:
     client = access_read_mongoDB()

--- a/ER_apis/ER_api.py
+++ b/ER_apis/ER_api.py
@@ -127,3 +127,11 @@ def request_free_characters(matchingMode: str = NORMAL_MODE_NUMBER) -> bool:
     if responced_datas.get("code", 0) != OK_RESPONSE:
         return False
     return True
+
+def request_top_players(seasonId:str=SEASON_ID, matchingTeamMode:str=RANK_MODE_NUMBER) -> dict | None:
+    responced_datas = request_to_ER_api(
+        request_url=f"https://open-api.bser.io/v1/rank/top/{seasonId}/{matchingTeamMode}"
+    )
+    if responced_datas.get("code", 0)!=OK_RESPONSE:
+        return None
+    return responced_datas


### PR DESCRIPTION
## PR Checklist

아래 요구사항을 만족하는지 체크:

- [ ]  작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ]  작성한 코드 문서화 (기능 추가 / 버그 개선)

## PR Type

해당 PR이 포함하는 내용 체크:

- [ ]  패키지
    - [ ]  패키지 추가
    - [ ]  패키지 설정 변경
- [ ]  문서화
    - [ ]  신규 문서 추가
    - [ ]  기존 문서 변경
- [x]  신규 기능 추가
- [ ]  버그 수정
- [x]  코드 개선
    - [ ]  성능 개선
    - [x]  성능에 영향을 끼치지 않는 수정
- [ ]  테스트
    - [ ]  테스트 코드 추가
    - [ ]  기존 테스트 코드 변경
- [ ]  커밋 되돌리기
- [ ]  기타

## 해당 PR에 대한 설명

### DB에 이터니티,데미갓 mmr 저장 스케줄러 구현

1. secret_db.json파일에서 읽어왔던 DB connect String을 env에서 읽어오는 것으로 변경
2. ER_DB.get_ranker_mmr()을 통해 이터니티/데미갓 mmr을 DB에서 읽어옴
3. 주기적(오전 9시)마다 DB에 mmr top 1000명의 데이터를 저장

## 기타 정보

## TODO

1. seasonId에 대한 자동 업데이트 처리 방안